### PR TITLE
Bump `syn` dep to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,9 +1012,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
 dependencies = [
  "unicode-xid",
 ]
@@ -1608,9 +1608,9 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Your `Cargo.lock` is currently locking an old version of the `syn`
crate. In future versions of Rust (in particular, once
https://github.com/rust-lang/rust/pull/77153) is merged), this may cause
your crate to stop compiling.

This PR bumps `syn` to the latest version in your `Cargo.lock`. This
ensures that your crate can compiler with both older and newer versions
of Rust.